### PR TITLE
Filtros de usuarios

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
 
 gem "roo", "~> 2.8"
+
+gem "ransack", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,10 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
+    ransack (2.5.0)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -268,6 +272,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)
   rails_12factor
+  ransack (~> 2.5)
   roo (~> 2.8)
   sass-rails (>= 6)
   selenium-webdriver
@@ -284,4 +289,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.2.14
+   2.3.22

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,8 @@ class UsersController < ApplicationController
   # GET /users
   # GET /users.json
   def index
-    @users = User.all
+    @q = User.ransack(params[:q])
+    @users = @q.result
   end
 
   # GET /users/1
@@ -42,7 +43,8 @@ class UsersController < ApplicationController
   def update
     respond_to do |format|
       if @user.update(user_params)
-        format.html { redirect_to @user, notice: 'User was successfully updated.' }
+        # format.html { redirect_to @user, notice: 'User was successfully updated.' }      
+        format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
         format.json { render :show, status: :ok, location: @user }
       else
         format.html { render :edit }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
   def update
     respond_to do |format|
       if @user.update(user_params)
-        format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
+        format.html { redirect_to users_url, notice: 'User was successfully updated.' }
         format.json { render :show, status: :ok, location: @user }
       else
         format.html { render :edit }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,19 @@ class UsersController < ApplicationController
   # GET /users
   # GET /users.json
   def index
-    @q = User.ransack(params[:q])
+    @params = params[:q]
+
+    if @params
+      @params.delete(:is_student_true) if @params[:is_student_true] == "0"
+      @params.delete(:is_professor_true) if @params[:is_professor_true] == "0"
+      @params.delete(:is_committee_member_true) if @params[:is_committee_member_true] == "0"
+      @params.delete(:is_judge_true) if @params[:is_judge_true] == "0"
+      @params.delete(:is_admin_true) if @params[:is_admin_true] == "0"
+      @params.delete(:is_visitor_true) if @params[:is_visitor_true] == "0"
+      @params.delete(:is_staff_member_true) if @params[:is_staff_member_true] == "0"
+    end
+
+    @q = User.ransack(@params)
     @users = @q.result
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,10 @@ class User < ApplicationRecord
     self.is_staff_member
   end
 
+  def committee_member_pending_approval?
+    professor? or judge? and !committee_member?
+  end
+
   def role
     roles = []
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -38,6 +38,12 @@
         <%= f.check_box :is_staff_member_true %>
         <%= f.label :is_staff_member_true, "Staff" %>
       </div>
+
+      <!-- En teoría esto no se debe hacer pero, ¿a quién le importa? -->
+      <div>
+        <%= f.check_box :is_staff_member_null %>
+        <%= f.label :is_staff_member_null, "Pendiente de aprovación" %>
+      </div>
     </div>
 
     <div class="m-3">
@@ -61,7 +67,7 @@
           <td><%= user.first_name %></td>
           <td><%= user.last_name %></td>
           <td>
-            <% if current_user.administrator? and user.professor? or user.judge? and !user.committee_member? %>
+            <% if current_user.administrator? and user.committee_member_pending_approval? %>
               <span class="glyphicon glyphicon-info-sign text-warning" data-toggle="tooltip" data-placement="top" title="Pendiente de asignar como miembro del comité"></span>
             <% end %>
             <%= user.role %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,6 +2,23 @@
 <div class="content">
   <h1>Usuarios</h1>
 
+  <%= search_form_for @q do |f| %>
+    <div class="d-flex justify-content-around">
+      <div>
+        <%= f.check_box :is_student_not_null %>
+        <%= f.label :is_student_not_null, "Estudiante" %>
+      </div>
+      <div>
+        <%= f.check_box :is_committee_member_not_null  %>
+        <%= f.label :is_committee_member_not_null, "Miembro del comite" %>
+      </div>
+    </div>
+
+    <div class="m-3">
+      <%= f.submit "Buscar" %>      
+    </div>
+  <% end %>
+
   <table class="table table-borderless">
     <thead class="thead-light">
       <tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,39 +5,38 @@
   <%= search_form_for @q do |f| %>
     <div class="d-flex justify-content-around">
       <div>
-        <%= f.check_box :is_student_not_null %>
-        <%= f.label :is_student_not_null, "Estudiante" %>
-      </div>
-      
-
-      <div>
-        <%= f.check_box :is_professor_not_null %>
-        <%= f.label :is_professor_not_null, "Profesor" %>
+        <%= f.check_box :is_student_true %>
+        <%= f.label :is_student_true, "Estudiante" %>
       </div>
 
       <div>
-        <%= f.check_box :is_committee_member_not_null  %>
-        <%= f.label :is_committee_member_not_null, "Miembro del comite" %>
+        <%= f.check_box :is_professor_true %>
+        <%= f.label :is_professor_true, "Profesor" %>
       </div>
 
       <div>
-        <%= f.check_box :is_judge_not_null %>
-        <%= f.label :is_judge_not_null, "Juez" %>
+        <%= f.check_box :is_committee_member_true  %>
+        <%= f.label :is_committee_member_true, "Miembro del comite" %>
       </div>
 
       <div>
-        <%= f.check_box :is_admin_not_null %>
-        <%= f.label :is_admin_not_null, "Administrador" %>
+        <%= f.check_box :is_judge_true %>
+        <%= f.label :is_judge_true, "Juez" %>
       </div>
 
       <div>
-        <%= f.check_box :is_visitor_not_null %>
-        <%= f.label :is_visitor_not_null, "Visitante" %>
+        <%= f.check_box :is_admin_true %>
+        <%= f.label :is_admin_true, "Administrador" %>
       </div>
 
       <div>
-        <%= f.check_box :is_staff_member_not_null %>
-        <%= f.label :is_staff_member_not_null, "Staff" %>
+        <%= f.check_box :is_visitor_true %>
+        <%= f.label :is_visitor_true, "Visitante" %>
+      </div>
+
+      <div>
+        <%= f.check_box :is_staff_member_true %>
+        <%= f.label :is_staff_member_true, "Staff" %>
       </div>
     </div>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,14 +8,41 @@
         <%= f.check_box :is_student_not_null %>
         <%= f.label :is_student_not_null, "Estudiante" %>
       </div>
+      
+
+      <div>
+        <%= f.check_box :is_professor_not_null %>
+        <%= f.label :is_professor_not_null, "Profesor" %>
+      </div>
+
       <div>
         <%= f.check_box :is_committee_member_not_null  %>
         <%= f.label :is_committee_member_not_null, "Miembro del comite" %>
       </div>
+
+      <div>
+        <%= f.check_box :is_judge_not_null %>
+        <%= f.label :is_judge_not_null, "Juez" %>
+      </div>
+
+      <div>
+        <%= f.check_box :is_admin_not_null %>
+        <%= f.label :is_admin_not_null, "Administrador" %>
+      </div>
+
+      <div>
+        <%= f.check_box :is_visitor_not_null %>
+        <%= f.label :is_visitor_not_null, "Visitante" %>
+      </div>
+
+      <div>
+        <%= f.check_box :is_staff_member_not_null %>
+        <%= f.label :is_staff_member_not_null, "Staff" %>
+      </div>
     </div>
 
     <div class="m-3">
-      <%= f.submit "Buscar" %>      
+      <%= f.submit "Buscar", class: "btn btn-primary" %>      
     </div>
   <% end %>
 


### PR DESCRIPTION
# Cambios
- Requerimientos funcionales RF46 y RF36.
- Miembros del comité y administradores pueden filtrar a los usuarios segun su rol y si falta su aprovación.
- Para lograr lo anterior, se añadió la gema ransack

# Preguntas al profe
- ¿Ya existe producción? ¿Hay usuarios registrados?
- ¿Qué usuarios son los que necesitan ser aprovados como miembros de comité?
- ¿Qué usuarios son los que necesitan ser aprovados como profesor o evaluador?
- ¿Debería poder buscar a alguien por su nombre?

# Review
- [x] Alam
- [ ] Elias
- [ ] Natacion
- [ ] Dino Adrian