### PR TITLE
Añadir edición en miembro del comité

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
   def update
     respond_to do |format|
       @params = params.require(:user).permit(
-        :first_name, :last_name, :is_committee_member, :department, :institution_id
+        :first_name, :last_name, :is_committee_member, :department, :institution_id, :edition_id
       )
       get_approveed_param(params)
       if save_user
@@ -105,6 +105,15 @@ class UsersController < ApplicationController
     if @user.professors.any?
       @professor = @user.professors.first
       @professor.approved = true
+    end
+  end
+
+  def get_committee_member_param
+    if @params[:is_committee_member] != @user.is_committee_member
+      @committee_member = @user.is_committee_members.first
+      if @committee_member
+        # TODO: Lol
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -108,15 +108,6 @@ class UsersController < ApplicationController
     end
   end
 
-  def get_committee_member_param
-    if @params[:is_committee_member] != @user.is_committee_member
-      @committee_member = @user.is_committee_members.first
-      if @committee_member
-        # TODO: Lol
-      end
-    end
-  end
-
   def fix_filter_params
     if @params
       # TODO: Make pending_approval to be filter with ransack 

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -2,7 +2,13 @@ module EditionsHelper
 
   def edition_options
     get_current_editions.collect do |edition|
-        [edition.name, edition.id]
+      [edition.name, edition.id]
+    end
+  end
+
+  def all_edition_options
+    Edition.all.collect do |edition|
+      [edition.name, edition.id]
     end
   end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -53,6 +53,12 @@
           <%= form.text_field :student_code, :class => "form-control" %>
         </div>
       <% end %>
+      <% if current_user.can_update_users? and user.committee_member? %>
+        <%= form.label :edition, "Edición", :class => "col-sm-3 col-form-label" %>
+        <div class="col-sm-9">
+          <%= form.select :institution_id, edition_options(), {}, :class => "form-control"  %>
+        </div>
+      <% end %>
       <% if current_user.can_update_users? and user.professor? or user.judge? or user.committee_member? %>
         <div class="col-sm-3 col-form-label mt-2">
           <%= form.label :is_committee_member, "Miembro del comité" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -56,7 +56,7 @@
       <% if current_user.can_update_users? and user.committee_member? %>
         <%= form.label :edition, "Edición", :class => "col-sm-3 col-form-label" %>
         <div class="col-sm-9">
-          <%= form.select :institution_id, edition_options(), {}, :class => "form-control"  %>
+          <%= form.select :institution_id, all_edition_options(), {}, :class => "form-control"  %>
         </div>
       <% end %>
       <% if current_user.can_update_users? and user.professor? or user.judge? or user.committee_member? %>

--- a/db/migrate/20221106211710_add_approval_attributes_to_committee_members.rb
+++ b/db/migrate/20221106211710_add_approval_attributes_to_committee_members.rb
@@ -1,0 +1,7 @@
+class AddApprovalAttributesToCommitteeMembers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :committee_members, :can_approve_committee_members, :boolean, default: false
+    add_column :committee_members, :active, :boolean, default: false
+    add_reference :committee_members, :edition, index: true
+  end
+end

--- a/db/migrate/20221106211710_add_approval_attributes_to_committee_members.rb
+++ b/db/migrate/20221106211710_add_approval_attributes_to_committee_members.rb
@@ -1,7 +1,7 @@
 class AddApprovalAttributesToCommitteeMembers < ActiveRecord::Migration[6.0]
   def change
     add_column :committee_members, :can_approve_committee_members, :boolean, default: false
-    add_column :committee_members, :active, :boolean, default: false
+    add_column :committee_members, :active, :boolean, default: true
     add_reference :committee_members, :edition, index: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_020849) do
+ActiveRecord::Schema.define(version: 2022_11_06_211710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,10 @@ ActiveRecord::Schema.define(version: 2022_11_04_020849) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.boolean "can_approve_committee_members", default: false
+    t.boolean "active", default: false
+    t.bigint "edition_id"
+    t.index ["edition_id"], name: "index_committee_members_on_edition_id"
     t.index ["user_id"], name: "index_committee_members_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2022_11_06_211710) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.boolean "can_approve_committee_members", default: false
-    t.boolean "active", default: false
+    t.boolean "active", default: true
     t.bigint "edition_id"
     t.index ["edition_id"], name: "index_committee_members_on_edition_id"
     t.index ["user_id"], name: "index_committee_members_on_user_id"


### PR DESCRIPTION
# Cambios
- Requerimiento funcional RF51.
- Se modificó la base de datos para que el miembro del comité tenga los siguientes attributos:
  - `can_approve_committee_members`: para aprobar otros miembros del comité (este atributo se usará en un futuro PR de @JeG99)
  - `active`: conocer si se está activo (este atributo se usará en un futuro PR
  -  `edition_id`: Para conocer la edición en la que participa.
- Se puede agregar una edición en la cual el mimebro del comité participa.

# Actualizar los cambios de la DB en tu local
Para tener estos cambios en tu local, es necesario migrar el proyecto. Lo puedes hacer así
1. Abrir una terminal de docker, lo puedes hacer con este comando: `docker exec -it webapp bash`
2. Dentro de la terminal anteriormente abierta, correr las migraciones con: `rails db:migrate`

# Review
- [ ] Alam
- [x] Elias
- [x] Natacion
- [ ] Dino Adrian